### PR TITLE
Compile fix for msvc

### DIFF
--- a/gmp_compat.c
+++ b/gmp_compat.c
@@ -36,6 +36,14 @@
 #define CHECK(res) assert(((res) == MP_OK) && "expected MP_OK")
 #endif
 
+#ifdef _MSC_VER
+#ifdef _WIN64
+typedef signed __int64 ssize_t;
+#else
+typedef signed int ssize_t;
+#endif
+#endif
+
 /* *(signed char *)&endian_test will thus either be:
  *     0b00000001 =  1 on big-endian
  *     0b11111111 = -1 on little-endian */


### PR DESCRIPTION
The type ssize_t is a POSIX extension to the C language and hence not available on the windows platform. Add a typedef to the corresponding signed type of size_t when compiling with msvc.